### PR TITLE
Initialize ctrl_msg struct for older version GCC compatibility

### DIFF
--- a/nvidia/drivers/net/ethernet/nvidia/pcie/tegra_vnet.c
+++ b/nvidia/drivers/net/ethernet/nvidia/pcie/tegra_vnet.c
@@ -857,6 +857,7 @@ static void process_ctrl_msg(struct work_struct *work)
 	struct ep_ring_buf *ep_mem = &tvnet->ep_mem;
 	struct ep_own_cnt *ep_cnt = ep_mem->ep_cnt;
 	struct ctrl_msg msg;
+	memset(&msg, 0, sizeof(msg));
 
 	while (tvnet_ivc_rd_available(ep_cnt, host_cnt, EP2H_CTRL)) {
 		tvnet_read_ctrl_msg(tvnet, &msg);

--- a/nvidia/drivers/pci/endpoint/functions/pci-epf-tegra-vnet.c
+++ b/nvidia/drivers/pci/endpoint/functions/pci-epf-tegra-vnet.c
@@ -922,6 +922,7 @@ static void process_ctrl_msg(struct work_struct *work)
 	struct ep_ring_buf *ep_ring_buf = &tvnet->ep_ring_buf;
 	struct ep_own_cnt *ep_cnt = ep_ring_buf->ep_cnt;
 	struct ctrl_msg msg;
+	memset(&msg, 0, sizeof(msg));
 
 	while (tvnet_ivc_rd_available(ep_cnt, host_cnt, H2EP_CTRL)) {
 		tvnet_read_ctrl_msg(tvnet, &msg);


### PR DESCRIPTION
When compiling the source code using an older version of cross-compiler,
e.g. aarch64-linux-gnu-gcc-5.4.0, the compiler reports errors such as this:

`error: ‘msg.msg_id’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   else if (msg.msg_id == CTRL_MSG_LINK_DOWN_ACK)`

This kind of error would not appear if using late version of GCC.
For back-compatibility consideration, this commit added initialization to functions.
    
