### PR TITLE
kbuild: change kernel version line order in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+
+VERSION = 4
+PATCHLEVEL = 9
+SUBLEVEL = 140
+EXTRAVERSION =
+NAME = Roaring Lionus
+
 ifeq ($(KERNEL_OVERLAYS),)
 KERNEL_OVERLAYS :=
 KERNEL_OVERLAYS += $(CURDIR)/nvidia
@@ -14,12 +21,6 @@ define set_srctree_overlay
   export srctree.$(overlay_name)
 endef
 $(foreach overlay,$(KERNEL_OVERLAYS),$(eval $(value set_srctree_overlay)))
-
-VERSION = 4
-PATCHLEVEL = 9
-SUBLEVEL = 140
-EXTRAVERSION =
-NAME = Roaring Lionus
 
 # *DOCUMENTATION*
 # To see a list of typical targets execute "make help"


### PR DESCRIPTION
for Yocto-devtool compatibility.

When "devtool modify linux-tegra" is invoked in a Yocto setup, get_staging_kver function in poky/scripts/lib/devtool/standard.py results in a parse error. Devtool parses first few lines for the kernel version with its current implementation. Therefore to make linux-tegra Makefile compatible with devtool, first few lines should contain kernel version information.
This patch could be cherry-picked to the other compatible branches.

Signed-off-by: Mustafa Özçelikörs <mozcelikors@gmail.com>