### PR TITLE
iommu/arm-smmu: typo fix (adr -> addr)

### DIFF
--- a/drivers/iommu/arm-smmu.c
+++ b/drivers/iommu/arm-smmu.c
@@ -1607,7 +1607,7 @@ static void *arm_smmu_alloc_pgtable_page(struct arm_smmu_domain *domain, int lvl
 		pud_t *pud;
 
 		if (!pgd_none(*pgd)) {
-			ret = pud_offset(pgd, adr);
+			ret = pud_offset(pgd, addr);
 			goto unlock_ret;
 		}
 

--- a/nvidia/drivers/iommu/arm-smmu-t19x.c
+++ b/nvidia/drivers/iommu/arm-smmu-t19x.c
@@ -1890,7 +1890,7 @@ static void *arm_smmu_alloc_pgtable_page(struct arm_smmu_domain *domain, int lvl
 		pud_t *pud;
 
 		if (!pgd_none(*pgd)) {
-			ret = pud_offset(pgd, adr);
+			ret = pud_offset(pgd, addr);
 			goto unlock_ret;
 		}
 


### PR DESCRIPTION
Fixes the build when using 48-bit VAs.