### PR TITLE
fixed missing data type cast which was generating a warning/error.

### DIFF
--- a/drivers/scsi/iscsi_tcp.c
+++ b/drivers/scsi/iscsi_tcp.c
@@ -402,7 +402,7 @@ static int iscsi_sw_tcp_send_hdr_done(struct iscsi_tcp_conn *tcp_conn,
 
 	tcp_sw_conn->out.segment = tcp_sw_conn->out.data_segment;
 	ISCSI_SW_TCP_DBG(tcp_conn->iscsi_conn,
-			 "Header done. Next segment size %u total_size %u\n",
+			 "Header done. Next segment size %u total_size %lu\n",
 			 tcp_sw_conn->out.segment.size,
 			 tcp_sw_conn->out.segment.total_size);
 	return 0;

--- a/drivers/scsi/libiscsi_tcp.c
+++ b/drivers/scsi/libiscsi_tcp.c
@@ -100,7 +100,7 @@ iscsi_tcp_segment_init_sg(struct iscsi_segment *segment,
 	segment->sg = sg;
 	segment->sg_offset = offset;
 	segment->size = min(sg->length - offset,
-    	segment->total_size - segment->total_copied);
+    			    segment->total_size - segment->total_copied);
 	segment->data = NULL;
 }
 

--- a/drivers/scsi/libiscsi_tcp.c
+++ b/drivers/scsi/libiscsi_tcp.c
@@ -99,8 +99,8 @@ iscsi_tcp_segment_init_sg(struct iscsi_segment *segment,
 {
 	segment->sg = sg;
 	segment->sg_offset = offset;
-	segment->size = min(sg->length - offset,
-			    segment->total_size - segment->total_copied);
+	segment->size = min((unsigned int)(sg->length - offset),
+			    (unsigned int)(segment->total_size - segment->total_copied));
 	segment->data = NULL;
 }
 

--- a/drivers/scsi/libiscsi_tcp.c
+++ b/drivers/scsi/libiscsi_tcp.c
@@ -95,12 +95,12 @@ static int iscsi_tcp_hdr_recv_done(struct iscsi_tcp_conn *tcp_conn,
  */
 static inline void
 iscsi_tcp_segment_init_sg(struct iscsi_segment *segment,
-			  struct scatterlist *sg, unsigned int offset)
+			  struct scatterlist *sg, unsigned long offset)
 {
 	segment->sg = sg;
 	segment->sg_offset = offset;
-	segment->size = min((unsigned int)(sg->length - offset),
-			    (unsigned int)(segment->total_size - segment->total_copied));
+	segment->size = min(sg->length - offset,
+    segment->total_size - segment->total_copied);
 	segment->data = NULL;
 }
 
@@ -232,12 +232,11 @@ int iscsi_tcp_segment_done(struct iscsi_tcp_conn *tcp_conn,
 	iscsi_tcp_segment_unmap(segment);
 
 	/* Do we have more scatterlist entries? */
-	ISCSI_DBG_TCP(tcp_conn->iscsi_conn, "total copied %u total size %u\n",
+	ISCSI_DBG_TCP(tcp_conn->iscsi_conn, "total copied %lu total size %lu\n",
 		      segment->total_copied, segment->total_size);
 	if (segment->total_copied < segment->total_size) {
 		/* Proceed to the next entry in the scatterlist. */
-		iscsi_tcp_segment_init_sg(segment, sg_next(segment->sg),
-					  0);
+		iscsi_tcp_segment_init_sg(segment, sg_next(segment->sg), 0);
 		iscsi_tcp_segment_map(segment, recv);
 		BUG_ON(segment->size == 0);
 		return 0;
@@ -371,7 +370,7 @@ EXPORT_SYMBOL_GPL(iscsi_segment_init_linear);
 inline int
 iscsi_segment_seek_sg(struct iscsi_segment *segment,
 		      struct scatterlist *sg_list, unsigned int sg_count,
-		      unsigned int offset, size_t size,
+		      unsigned long offset, size_t size,
 		      iscsi_segment_done_fn_t *done,
 		      struct ahash_request *hash)
 {

--- a/drivers/scsi/libiscsi_tcp.c
+++ b/drivers/scsi/libiscsi_tcp.c
@@ -100,7 +100,7 @@ iscsi_tcp_segment_init_sg(struct iscsi_segment *segment,
 	segment->sg = sg;
 	segment->sg_offset = offset;
 	segment->size = min(sg->length - offset,
-    segment->total_size - segment->total_copied);
+    	segment->total_size - segment->total_copied);
 	segment->data = NULL;
 }
 

--- a/include/scsi/libiscsi_tcp.h
+++ b/include/scsi/libiscsi_tcp.h
@@ -35,7 +35,7 @@ struct iscsi_segment {
 	unsigned char		*data;
 	unsigned int 		size;
 	unsigned int		copied;
-	size_t		      total_size;
+	size_t		      	total_size;
 	unsigned long		total_copied;
 
 	struct ahash_request	*hash;

--- a/include/scsi/libiscsi_tcp.h
+++ b/include/scsi/libiscsi_tcp.h
@@ -33,10 +33,10 @@ typedef int iscsi_segment_done_fn_t(struct iscsi_tcp_conn *,
 
 struct iscsi_segment {
 	unsigned char		*data;
-	unsigned int		size;
+	unsigned int 		size;
 	unsigned int		copied;
-	unsigned int		total_size;
-	unsigned int		total_copied;
+	size_t		      total_size;
+	unsigned long		total_copied;
 
 	struct ahash_request	*hash;
 	unsigned char		padbuf[ISCSI_PAD_LEN];
@@ -46,7 +46,7 @@ struct iscsi_segment {
 
 	struct scatterlist	*sg;
 	void			*sg_mapped;
-	unsigned int		sg_offset;
+	unsigned long		sg_offset;
 	bool			atomic_mapped;
 
 	iscsi_segment_done_fn_t	*done;
@@ -115,7 +115,7 @@ extern void iscsi_segment_init_linear(struct iscsi_segment *segment,
 extern int
 iscsi_segment_seek_sg(struct iscsi_segment *segment,
 		      struct scatterlist *sg_list, unsigned int sg_count,
-		      unsigned int offset, size_t size,
+		      unsigned long offset, size_t size,
 		      iscsi_segment_done_fn_t *done,
 		      struct ahash_request *hash);
 


### PR DESCRIPTION
While I'm not sure if this matters to anyone, I was attempting to get the iSCSI driver to compile and ran into this issue.  Not sure if this is the appropriate place to submit, but at least if someone searches for anything like "iscsid: can not create NETLINK_ISCSI socket" and cannot figure out why iscsid is hanging, and modprobe iscsi_tcp says the module doesn't exist...  Or while trying to compile a new kernel for the Jetson Nano to include the iscsi_tcp kernel driver, etc. and runs across this error, hopefully they'll find this post.  Or maybe it'll just be me the next time I forget what I did to get this working.
