### PR TITLE
nvidia: net/wireless/bcmdhd: fix ignoring core reg notifications

### DIFF
--- a/nvidia/drivers/net/wireless/bcmdhd/wl_cfg80211.c
+++ b/nvidia/drivers/net/wireless/bcmdhd/wl_cfg80211.c
@@ -8653,6 +8653,11 @@ wl_cfg80211_reg_notifier(
 		(request->initiator != NL80211_REGDOM_SET_BY_COUNTRY_IE)) {
 		WL_ERR(("reg_notifier for intiator:%d not supported : set default\n",
 			request->initiator));
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 10, 0))
+		return -EINVAL;
+#else
+		return;
+#endif /* kernel version < 3.10.0 */
 		/* in case of no supported country by regdb
 		     lets driver setup platform default Locale
 		*/

--- a/nvidia/drivers/net/wireless/bcmdhd_pcie/wl_cfg80211.c
+++ b/nvidia/drivers/net/wireless/bcmdhd_pcie/wl_cfg80211.c
@@ -9677,6 +9677,11 @@ wl_cfg80211_reg_notifier(
 		(request->initiator != NL80211_REGDOM_SET_BY_COUNTRY_IE)) {
 		WL_ERR(("reg_notifier for intiator:%d not supported : set default\n",
 			request->initiator));
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 10, 0))
+		return -EINVAL;
+#else
+		return;
+#endif /* kernel version < 3.10.0 */
 		/* in case of no supported country by regdb
 		     lets driver setup platform default Locale
 		*/


### PR DESCRIPTION
An error was reported, but the function was not returning
afterward, which was causing an invalid memory access.

Signed-off-by: Matt Madison <matt@madison.systems>