### PR TITLE
sound: core: seq: fix multiple definition of delete_and_unsubscribe_port

### DIFF
--- a/sound/core/seq/seq_ports.c
+++ b/sound/core/seq/seq_ports.c
@@ -569,19 +569,6 @@ static void delete_and_unsubscribe_port(struct snd_seq_client *client,
 	up_write(&grp->list_mutex);
 }
 
-static void delete_and_unsubscribe_port(struct snd_seq_client *client,
-					struct snd_seq_client_port *port,
-					struct snd_seq_subscribers *subs,
-					bool is_src, bool ack)
-{
-	struct snd_seq_port_subs_info *grp;
-
-	grp = is_src ? &port->c_src : &port->c_dest;
-	down_write(&grp->list_mutex);
-	__delete_and_unsubscribe_port(client, port, subs, is_src, ack);
-	up_write(&grp->list_mutex);
-}
-
 /* connect two ports */
 int snd_seq_port_connect(struct snd_seq_client *connector,
 			 struct snd_seq_client *src_client,


### PR DESCRIPTION
Fixes a build failure due to multiple definition of delete_and_unsubscribe_port.