### PR TITLE
Make kernel modules build with gcc 13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -683,8 +683,9 @@ KBUILD_CFLAGS	+= $(call cc-disable-warning, format-overflow)
 KBUILD_CFLAGS	+= $(call cc-disable-warning, int-in-bool-context)
 KBUILD_CFLAGS	+= $(call cc-disable-warning, address-of-packed-member)
 KBUILD_CFLAGS	+= $(call cc-disable-warning, attribute-alias)
-KBUILD_CFLAGS   += $(call cc-disable-warning, address-of-packed-member)
-KBUILD_CFLAGS   += $(call cc-disable-warning, packed-not-aligned)
+KBUILD_CFLAGS	+= $(call cc-disable-warning, packed-not-aligned)
+KBUILD_CFLAGS	+= $(call cc-disable-warning, dangling-pointer)
+KBUILD_CFLAGS	+= $(call cc-disable-warning, enum-int-mismatch)
 
 ifdef CONFIG_LD_DEAD_CODE_DATA_ELIMINATION
 KBUILD_CFLAGS	+= $(call cc-option,-ffunction-sections,)

--- a/drivers/infiniband/ulp/srp/ib_srp.h
+++ b/drivers/infiniband/ulp/srp/ib_srp.h
@@ -62,10 +62,12 @@ enum {
 	SRP_DEFAULT_CMD_SQ_SIZE = SRP_DEFAULT_QUEUE_SIZE - SRP_RSP_SQ_SIZE -
 				  SRP_TSK_MGMT_SQ_SIZE,
 
+	SRP_MAX_PAGES_PER_MR	= 512,
+};
+
+enum {
 	SRP_TAG_NO_REQ		= ~0U,
 	SRP_TAG_TSK_MGMT	= 1U << 31,
-
-	SRP_MAX_PAGES_PER_MR	= 512,
 };
 
 enum srp_target_state {


### PR DESCRIPTION
I am working on updating the Jetpack 4 meta-tegra version to [scarthgap-l4t-r32-7.x](https://github.com/recoord/meta-tegra/tree/scarthgap-l4t-r32.7.x). This PR fixes some errors and warnings when building the kernel with gcc 13.4, that is shipped with Scarthgap.